### PR TITLE
support callable on dummy module

### DIFF
--- a/dummy_module.lua
+++ b/dummy_module.lua
@@ -1,0 +1,6 @@
+local M = {}
+
+function M.foo()
+end
+
+return M

--- a/mymod.lua
+++ b/mymod.lua
@@ -1,3 +1,7 @@
+local dummy_mod = require "dummy_module"
+
+dummy_mod.foo()
+
 local mod = {}
 
 local a = 1

--- a/mymod_update.lua
+++ b/mymod_update.lua
@@ -1,4 +1,7 @@
 local debug = require "debug"
+local dummy_mod = require "dummy_module"
+
+dummy_mod.foo()
 
 local mod = {}
 

--- a/reload.lua
+++ b/reload.lua
@@ -497,17 +497,17 @@ local function merge_objects(all)
 	end
 end
 
-local function slove_globals(all)
+local function solve_globals(all)
 	local _LOADED = debug.getregistry()._LOADED
 	local print = reload.print
 	local i = 0
 	for mod_name, data in pairs(all) do
 		for gk, item in pairs(data.globals) do
-			-- slove one global
+			-- solve one global
 			local v = item[1]
 			local path = tostring(v)
 			local value
-			local unsloved
+			local unsolved
 			local invalid
 			if getmetatable(v) == "GLOBAL" then
 				local G = _G
@@ -541,14 +541,14 @@ local function slove_globals(all)
 					local mt = getmetatable(mod)
 					if mt == "MODULE" then
 					else
-						unsloved = true
+						unsolved = true
 						value = mod
 					end
 			end
 			if invalid then
 				if print then print("GLOBAL INVALID", path) end
 				data.globals[gk] = nil
-			elseif not unsloved then
+			elseif not unsolved then
 				i = i + 1
 				if print then print("GLOBAL", path, value) end
 				set_object(value, _LOADED[mod_name], table.unpack(item,2))
@@ -729,7 +729,7 @@ function reload.reload(list)
 	end
 
 	repeat
-		local n = slove_globals(result)
+		local n = solve_globals(result)
 	until n == 0
 
 	local func_map = {}

--- a/reload.lua
+++ b/reload.lua
@@ -39,6 +39,7 @@ local module_dummy_mt = {
 	__newindex = error,
 	__pairs = error,
 	__tostring = function(self) return dummy_module_cache[self] end,
+	__call = function(...) end
 }
 
 local function make_dummy_module(name)


### PR DESCRIPTION
模块A require的模块M，可能会在模块A中有直接在模块级别的函数调用。
比如这个：
https://github.com/cloudwu/luareload/commit/b08976760ce488258934589012b0d498cd619449#diff-1d9b434aeafff50bfe7b8a84a0100ba6R3

不太确定直接就给dummy module加上__call是否合适，麻烦云风看看OK不，想到还有个做法则是把dummy_module_mt挂reload上返回，让用户自定义相关行为。

ps:另外还有个提交修了typo。